### PR TITLE
VAV風量の桁数を修正しました

### DIFF
--- a/jjjexperiment/constants.py
+++ b/jjjexperiment/constants.py
@@ -52,7 +52,7 @@ a_r_H_t_t_a1: float = 0.2944
 """コンプレッサ効率特性_a1"""
 a_r_H_t_t_a0: float = 0
 """コンプレッサ効率特性_a0"""
-airvolume_coeff_minimum: float = 0.17
+airvolume_minimum: float = 0.17  # km3/h
 """風量特性_中間期及び最小風量"""
 airvolume_coeff_a4_H: float = 0
 """風量特性_a4"""
@@ -195,9 +195,9 @@ def set_constants(input: dict):
       a_r_H_t_t_a1 = float(input['H_A']['compressor_coeff'][3])
       global a_r_H_t_t_a0 
       a_r_H_t_t_a0 = float(input['H_A']['compressor_coeff'][4])
-    if 'airvolume_coeff_minimum' in input['H_A']:
-      global airvolume_coeff_minimum_H 
-      airvolume_coeff_minimum_H = float(input['H_A']['airvolume_coeff_minimum'][0])
+    if 'airvolume_minimum' in input['H_A']:
+      global airvolume_minimum_H
+      airvolume_minimum_H = float(input['H_A']['airvolume_minimum'])
     if 'airvolume_coeff' in input['H_A']:
       global airvolume_coeff_a4_H 
       airvolume_coeff_a4_H = float(input['H_A']['airvolume_coeff'][0])
@@ -255,9 +255,9 @@ def set_constants(input: dict):
       a_r_C_t_t_a1 = float(input['C_A']['compressor_coeff'][3])
       global a_r_C_t_t_a0 
       a_r_C_t_t_a0 = float(input['C_A']['compressor_coeff'][4])
-    if 'airvolume_coeff_minimum' in input['C_A']:
-      global airvolume_coeff_minimum_C 
-      airvolume_coeff_minimum_C = float(input['C_A']['airvolume_coeff_minimum'][0])
+    if 'airvolume_minimum' in input['C_A']:
+      global airvolume_minimum_C
+      airvolume_minimum_C = float(input['C_A']['airvolume_minimum'])
     if 'airvolume_coeff' in input['C_A']:
       global airvolume_coeff_a4_C
       airvolume_coeff_a4_C = float(input['C_A']['airvolume_coeff'][0])

--- a/jjjexperiment/jjj_section4_2.py
+++ b/jjjexperiment/jjj_section4_2.py
@@ -1315,7 +1315,7 @@ def get_V_dash_hs_supply_d_t_2023(Q_hat_hs_d_t, region):
 
     # 暖房期：顕熱2.5kW未満
     f1 = np.logical_and(H, Q_hat_hs_d_t_kw < 2.5)
-    V_dash_hs_supply_d_t[f1] = constants.airvolume_coeff_minimum
+    V_dash_hs_supply_d_t[f1] = constants.airvolume_minimum
     # 暖房期：顕熱2.5kW以上
     f2 = np.logical_and(H, Q_hat_hs_d_t_kw >= 2.5)
     V_dash_hs_supply_d_t[f2] =  \
@@ -1327,7 +1327,7 @@ def get_V_dash_hs_supply_d_t_2023(Q_hat_hs_d_t, region):
 
     # 冷房期：顕熱2.5kW未満
     f3 = np.logical_and(C, Q_hat_hs_d_t_kw < 2.5)
-    V_dash_hs_supply_d_t[f3] = constants.airvolume_coeff_minimum
+    V_dash_hs_supply_d_t[f3] = constants.airvolume_minimum
     # 冷房期：顕熱2.5kW以上
     f4 = np.logical_and(C, Q_hat_hs_d_t_kw >= 2.5)
     V_dash_hs_supply_d_t[f4] =  \
@@ -1338,9 +1338,9 @@ def get_V_dash_hs_supply_d_t_2023(Q_hat_hs_d_t, region):
             + constants.airvolume_coeff_a0_C)[f4]
 
     # 中間期
-    V_dash_hs_supply_d_t[M] = constants.airvolume_coeff_minimum
+    V_dash_hs_supply_d_t[M] = constants.airvolume_minimum
 
-    return V_dash_hs_supply_d_t
+    return V_dash_hs_supply_d_t * 1000  # NOTE: km3/h -> m3/h
 
 def get_V_dash_hs_supply_d_t(V_hs_min, V_hs_dsgn_H, V_hs_dsgn_C, Q_hs_rtd_H, Q_hs_rtd_C, Q_hat_hs_d_t, region):
     """(36-1)(36-2)(36-3)

--- a/tests/test_latent_load_01.py
+++ b/tests/test_latent_load_01.py
@@ -254,15 +254,15 @@ class Test風量特性_熱源機_低出力:
 
     def test_暖房時_指定定数(self):
         ii = np.where(self._H == True)[0]
-        assert np.all(self._sut[ii] == consts.airvolume_minimum)
+        assert np.all(self._sut[ii] == consts.airvolume_minimum * 1000)  # m3/h
 
     def test_冷房時_指定定数(self):
         ii = np.where(self._C == True)[0]
-        assert np.all(self._sut[ii] == consts.airvolume_minimum)
+        assert np.all(self._sut[ii] == consts.airvolume_minimum * 1000)  # m3/h
 
     def test_中間期_常に指定定数(self):
         ii = np.where(self._M == True)[0]
-        assert np.all(self._sut[ii] == consts.airvolume_minimum)
+        assert np.all(self._sut[ii] == consts.airvolume_minimum * 1000)  # m3/h
 
 class Test風量特性_熱源機_高出力:
 
@@ -294,15 +294,15 @@ class Test風量特性_熱源機_高出力:
 
     def test_暖房時_四次式計算(self):
         ii = np.where(self._H == True)[0]
-        assert np.all(self._sut[ii] == self._inputs['H_A']['airvolume_coeff'][-1])
+        assert np.all(self._sut[ii] == self._inputs['H_A']['airvolume_coeff'][-1] * 1000)  # m3/h
 
     def test_冷房時_四次式計算(self):
         ii = np.where(self._C == True)[0]
-        assert np.all(self._sut[ii] == self._inputs['C_A']['airvolume_coeff'][-1])
+        assert np.all(self._sut[ii] == self._inputs['C_A']['airvolume_coeff'][-1] * 1000)  # m3/h
 
     def test_中間期_常に指定定数(self):
         ii = np.where(self._M == True)[0]
-        assert np.all(self._sut[ii] == consts.airvolume_minimum)
+        assert np.all(self._sut[ii] == consts.airvolume_minimum * 1000)  # m3/h
 
 
 def prepare_args_for_calc_Q_UT_A() -> dict:

--- a/tests/test_not_broken_various_inputs_type1.py
+++ b/tests/test_not_broken_various_inputs_type1.py
@@ -279,9 +279,9 @@ class Test既存計算維持_入力値切替_方式1:
         result = calc(inputs, test_mode=True)
 
         assert result['TValue'].E_H != expected_result_type1.E_H
-        assert math.close(result['TValue'].E_H, 141367.326695553)
+        assert math.isclose(result['TValue'].E_H, 141367.326695553)
         assert result['TValue'].E_C != expected_result_type1.E_C
-        assert math.close(result['TValue'].E_C, 3151.6467125592953)
+        assert math.isclose(result['TValue'].E_C, 3151.6467125592953)
 
     def test_入力値入替_18(self, expected_result_type1):
         """ 以前のプログラムと同じ計算結果になる

--- a/tests/test_not_broken_various_inputs_type1.py
+++ b/tests/test_not_broken_various_inputs_type1.py
@@ -1,6 +1,7 @@
 import pytest
 import json
 import copy
+import math
 
 from jjjexperiment.main import calc
 
@@ -51,7 +52,7 @@ class Test既存計算維持_入力値切替_方式1:
 
         assert result['TValue'].E_C == expected_result_type1.E_C
         assert result['TValue'].E_H != expected_result_type1.E_H
-        assert result['TValue'].E_H == 36312.73469516181
+        assert math.isclose(result['TValue'].E_H, 36312.73469516181)
 
     def test_入力値入替_02(self, expected_result_type1):
         """ 以前のプログラムと同じ計算結果になる
@@ -65,7 +66,7 @@ class Test既存計算維持_入力値切替_方式1:
 
         assert result['TValue'].E_H == expected_result_type1.E_H
         assert result['TValue'].E_C != expected_result_type1.E_C
-        assert result['TValue'].E_C == 14499.62278132686
+        assert math.isclose(result['TValue'].E_C, 14499.62278132686)
 
     def test_入力値入替_03(self, expected_result_type1):
         """ 以前のプログラムと同じ計算結果になる
@@ -79,7 +80,7 @@ class Test既存計算維持_入力値切替_方式1:
 
         assert result['TValue'].E_C == expected_result_type1.E_C
         assert result['TValue'].E_H != expected_result_type1.E_H
-        assert result['TValue'].E_H == 35890.90098587334
+        assert math.isclose(result['TValue'].E_H, 35890.90098587334)
 
     def test_入力値入替_04(self, expected_result_type1):
         """ 以前のプログラムと同じ計算結果になる
@@ -93,7 +94,7 @@ class Test既存計算維持_入力値切替_方式1:
 
         assert result['TValue'].E_C == expected_result_type1.E_C
         assert result['TValue'].E_H != expected_result_type1.E_H
-        assert result['TValue'].E_H == 36546.573126677504
+        assert math.isclose(result['TValue'].E_H, 36546.573126677504)
 
     def test_入力値入替_05(self, expected_result_type1):
         """ 以前のプログラムと同じ計算結果になる
@@ -107,7 +108,7 @@ class Test既存計算維持_入力値切替_方式1:
 
         assert result['TValue'].E_C == expected_result_type1.E_C
         assert result['TValue'].E_H != expected_result_type1.E_H
-        assert result['TValue'].E_H == 36611.49578865069
+        assert math.isclose(result['TValue'].E_H, 36611.49578865069)
 
     def test_入力値入替_06(self, expected_result_type1):
         """ 以前のプログラムと同じ計算結果になる
@@ -120,9 +121,9 @@ class Test既存計算維持_入力値切替_方式1:
         result = calc(inputs, test_mode=True)
 
         assert result['TValue'].E_H != expected_result_type1.E_H
-        assert result['TValue'].E_H == 36646.91339321118
+        assert math.isclose(result['TValue'].E_H, 36646.91339321118)
         assert result['TValue'].E_C != expected_result_type1.E_C
-        assert result['TValue'].E_C == 14803.44514208752
+        assert math.isclose(result['TValue'].E_C, 14803.44514208752)
 
     def test_入力値入替_07(self, expected_result_type1):
         """ 以前のプログラムと同じ計算結果になる
@@ -136,7 +137,7 @@ class Test既存計算維持_入力値切替_方式1:
 
         assert result['TValue'].E_C == expected_result_type1.E_C
         assert result['TValue'].E_H != expected_result_type1.E_H
-        assert result['TValue'].E_H == 35836.748455098634
+        assert math.isclose(result['TValue'].E_H, 35836.748455098634)
 
     def test_入力値入替_08(self, expected_result_type1):
         """ 以前のプログラムと同じ計算結果になる
@@ -149,7 +150,7 @@ class Test既存計算維持_入力値切替_方式1:
         result = calc(inputs, test_mode=True)
 
         assert result['TValue'].E_H == expected_result_type1.E_H
-        assert result['TValue'].E_C == 14646.69148373989
+        assert math.isclose(result['TValue'].E_C, 14646.69148373989)
         assert result['TValue'].E_C != expected_result_type1.E_C
 
     def test_入力値入替_09(self, expected_result_type1):
@@ -232,9 +233,9 @@ class Test既存計算維持_入力値切替_方式1:
 
         result = calc(inputs, test_mode=True)
 
-        assert result['TValue'].E_H == 40461.6302264345
+        assert math.isclose(result['TValue'].E_H, 40461.6302264345)
         assert result['TValue'].E_H != expected_result_type1.E_H
-        assert result['TValue'].E_C == 14832.537841444147
+        assert math.isclose(result['TValue'].E_C, 14832.537841444147)
         assert result['TValue'].E_C != expected_result_type1.E_C
 
     def test_入力値入替_15(self, expected_result_type1):
@@ -247,9 +248,9 @@ class Test既存計算維持_入力値切替_方式1:
 
         result = calc(inputs, test_mode=True)
 
-        assert result['TValue'].E_H == 42391.84140416556
+        assert math.isclose(result['TValue'].E_H, 42391.84140416556)
         assert result['TValue'].E_H != expected_result_type1.E_H
-        assert result['TValue'].E_C == 21443.382718755827
+        assert math.isclose(result['TValue'].E_C, 21443.382718755827)
         assert result['TValue'].E_C != expected_result_type1.E_C
 
     def test_入力値入替_16(self, expected_result_type1):
@@ -262,9 +263,9 @@ class Test既存計算維持_入力値切替_方式1:
 
         result = calc(inputs, test_mode=True)
 
-        assert result['TValue'].E_H == 49036.33660346446
+        assert math.isclose(result['TValue'].E_H, 49036.33660346446)
         assert result['TValue'].E_H != expected_result_type1.E_H
-        assert result['TValue'].E_C == 24217.967340540887
+        assert math.isclose(result['TValue'].E_C, 24217.967340540887)
         assert result['TValue'].E_C != expected_result_type1.E_C
 
     def test_入力値入替_17(self, expected_result_type1):
@@ -277,10 +278,10 @@ class Test既存計算維持_入力値切替_方式1:
 
         result = calc(inputs, test_mode=True)
 
-        assert result['TValue'].E_H == 141367.326695553
         assert result['TValue'].E_H != expected_result_type1.E_H
-        assert result['TValue'].E_C == 3151.6467125592953
+        assert math.close(result['TValue'].E_H, 141367.326695553)
         assert result['TValue'].E_C != expected_result_type1.E_C
+        assert math.close(result['TValue'].E_C, 3151.6467125592953)
 
     def test_入力値入替_18(self, expected_result_type1):
         """ 以前のプログラムと同じ計算結果になる
@@ -292,9 +293,9 @@ class Test既存計算維持_入力値切替_方式1:
 
         result = calc(inputs, test_mode=True)
 
-        assert result['TValue'].E_H == 42086.82025871831
+        assert math.isclose(result['TValue'].E_H, 42086.82025871831)
         assert result['TValue'].E_H != expected_result_type1.E_H
-        assert result['TValue'].E_C == 14867.887750721573
+        assert math.isclose(result['TValue'].E_C, 14867.887750721573)
         assert result['TValue'].E_C != expected_result_type1.E_C
 
     def test_入力値入替_19(self, expected_result_type1):
@@ -307,9 +308,9 @@ class Test既存計算維持_入力値切替_方式1:
 
         result = calc(inputs, test_mode=True)
 
-        assert result['TValue'].E_H == 44911.46410023861
+        assert math.isclose(result['TValue'].E_H, 44911.46410023861)
         assert result['TValue'].E_H != expected_result_type1.E_H
-        assert result['TValue'].E_C == 14005.505611991277
+        assert math.isclose(result['TValue'].E_C, 14005.505611991277)
         assert result['TValue'].E_C != expected_result_type1.E_C
 
     def test_入力値入替_20(self, expected_result_type1):
@@ -323,8 +324,8 @@ class Test既存計算維持_入力値切替_方式1:
         result = calc(inputs, test_mode=True)
 
         assert result['TValue'].E_H == expected_result_type1.E_H
-        assert result['TValue'].E_C == 16358.465844105795
         assert result['TValue'].E_C != expected_result_type1.E_C
+        assert math.isclose(result['TValue'].E_C, 16358.465844105795)
 
     def test_入力値入替_21(self, expected_result_type1):
         """ 以前のプログラムと同じ計算結果になる
@@ -337,7 +338,7 @@ class Test既存計算維持_入力値切替_方式1:
         result = calc(inputs, test_mode=True)
 
         assert result['TValue'].E_C == expected_result_type1.E_C
-        assert result['TValue'].E_H == 40516.98524230055
+        assert math.isclose(result['TValue'].E_H, 40516.98524230055)
         assert result['TValue'].E_H != expected_result_type1.E_H
 
     def test_入力値入替_22(self, expected_result_type1):
@@ -350,10 +351,10 @@ class Test既存計算維持_入力値切替_方式1:
 
         result = calc(inputs, test_mode=True)
 
-        assert result['TValue'].E_H == 34056.175244458456
         assert result['TValue'].E_H != expected_result_type1.E_H
-        assert result['TValue'].E_C == 13038.13319064152
+        assert math.isclose(result['TValue'].E_H, 34056.175244458456)
         assert result['TValue'].E_C != expected_result_type1.E_C
+        assert math.isclose(result['TValue'].E_C, 13038.13319064152)
 
     def test_入力値入替_23(self, expected_result_type1):
         """ 以前のプログラムと同じ計算結果になる
@@ -393,10 +394,10 @@ class Test既存計算維持_入力値切替_方式1:
 
         result = calc(inputs, test_mode=True)
 
-        assert result['TValue'].E_H == 59669.99880864711
         assert result['TValue'].E_H != expected_result_type1.E_H
-        assert result['TValue'].E_C == 18714.44515829817
+        assert math.isclose(result['TValue'].E_H, 59669.99880864711)
         assert result['TValue'].E_C != expected_result_type1.E_C
+        assert math.isclose(result['TValue'].E_C, 18714.44515829817)
 
     def test_入力値入替_26(self, expected_result_type1):
         """ 以前のプログラムと同じ計算結果になる
@@ -423,8 +424,8 @@ class Test既存計算維持_入力値切替_方式1:
         result = calc(inputs, test_mode=True)
 
         assert result['TValue'].E_C == expected_result_type1.E_C
-        assert result['TValue'].E_H == 34061.44658403281
         assert result['TValue'].E_H != expected_result_type1.E_H
+        assert math.isclose(result['TValue'].E_H, 34061.44658403281)
 
     def test_入力値入替_H1(self, expected_result_type1):
         """ 以前のプログラムと同じ計算結果になる
@@ -437,8 +438,8 @@ class Test既存計算維持_入力値切替_方式1:
         result = calc(inputs, test_mode=True)
 
         assert result['TValue'].E_C == expected_result_type1.E_C
-        assert result['TValue'].E_H == 34608.193798931
         assert result['TValue'].E_H != expected_result_type1.E_H
+        assert math.isclose(result['TValue'].E_H, 34608.193798931)
 
     def test_入力値入替_H2(self, expected_result_type1):
         """ 以前のプログラムと同じ計算結果になる
@@ -451,8 +452,8 @@ class Test既存計算維持_入力値切替_方式1:
         result = calc(inputs, test_mode=True)
 
         assert result['TValue'].E_C == expected_result_type1.E_C
-        assert result['TValue'].E_H == 36291.25164821471
         assert result['TValue'].E_H != expected_result_type1.E_H
+        assert math.isclose(result['TValue'].E_H, 36291.25164821471)
 
     def test_入力値入替_H3(self, expected_result_type1):
         """ 以前のプログラムと同じ計算結果になる
@@ -465,8 +466,8 @@ class Test既存計算維持_入力値切替_方式1:
         result = calc(inputs, test_mode=True)
 
         assert result['TValue'].E_C == expected_result_type1.E_C
-        assert result['TValue'].E_H == 37064.91576192836
         assert result['TValue'].E_H != expected_result_type1.E_H
+        assert math.isclose(result['TValue'].E_H, 37064.91576192836)
 
     def test_入力値入替_H4(self, expected_result_type1):
         """ 以前のプログラムと同じ計算結果になる
@@ -480,8 +481,8 @@ class Test既存計算維持_入力値切替_方式1:
         result = calc(inputs, test_mode=True)
 
         assert result['TValue'].E_C == expected_result_type1.E_C
-        assert result['TValue'].E_H == 32622.96874682381
         assert result['TValue'].E_H != expected_result_type1.E_H
+        assert math.isclose(result['TValue'].E_H, 32622.96874682381)
 
     def test_入力値入替_H5_方式1(self, expected_inputs, expected_result_type1):
         """ 以前のプログラムと同じ計算結果になる
@@ -510,7 +511,7 @@ class Test既存計算維持_入力値切替_方式1:
         assert result['TInput'].e_rtd_H == expected_inputs.e_rtd_H
 
         assert result['TValue'].E_C == expected_result_type1.E_C
-        assert result['TValue'].E_H == 81575.50253836498
+        assert math.isclose(result['TValue'].E_H, 81575.50253836498)
         assert result['TValue'].E_H != expected_result_type1.E_H
 
     def test_入力値入替_H6_方式1(self, expected_inputs, expected_result_type1):
@@ -540,8 +541,8 @@ class Test既存計算維持_入力値切替_方式1:
         assert result['TInput'].e_rtd_H == expected_inputs.e_rtd_H
 
         assert result['TValue'].E_C == expected_result_type1.E_C
-        assert result['TValue'].E_H == 72987.18193043352
         assert result['TValue'].E_H != expected_result_type1.E_H
+        assert math.isclose(result['TValue'].E_H, 72987.18193043352)
 
     def test_入力値入替_R1(self, expected_result_type1):
         """ 以前のプログラムと同じ計算結果になる
@@ -554,8 +555,8 @@ class Test既存計算維持_入力値切替_方式1:
         result = calc(inputs, test_mode=True)
 
         assert result['TValue'].E_H == expected_result_type1.E_H
-        assert result['TValue'].E_C == 14980.637500033028
         assert result['TValue'].E_C != expected_result_type1.E_C
+        assert math.isclose(result['TValue'].E_C, 14980.637500033028)
 
     def test_入力値入替_R2(self, expected_result_type1):
         """ 以前のプログラムと同じ計算結果になる
@@ -568,8 +569,8 @@ class Test既存計算維持_入力値切替_方式1:
         result = calc(inputs, test_mode=True)
 
         assert result['TValue'].E_H == expected_result_type1.E_H
-        assert result['TValue'].E_C == 12852.724729450114
         assert result['TValue'].E_C != expected_result_type1.E_C
+        assert math.isclose(result['TValue'].E_C, 12852.724729450114)
 
     def test_入力値入替_R3(self, expected_result_type1):
         """ 以前のプログラムと同じ計算結果になる
@@ -582,8 +583,8 @@ class Test既存計算維持_入力値切替_方式1:
         result = calc(inputs, test_mode=True)
 
         assert result['TValue'].E_H == expected_result_type1.E_H
-        assert result['TValue'].E_C == 15191.971001329612
         assert result['TValue'].E_C != expected_result_type1.E_C
+        assert math.isclose(result['TValue'].E_C, 15191.971001329612)
 
     def test_入力値入替_R4(self, expected_result_type1):
         """ 以前のプログラムと同じ計算結果になる
@@ -597,8 +598,8 @@ class Test既存計算維持_入力値切替_方式1:
         result = calc(inputs, test_mode=True)
 
         assert result['TValue'].E_H == expected_result_type1.E_H
-        assert result['TValue'].E_C == 13915.09558491048
         assert result['TValue'].E_C != expected_result_type1.E_C
+        assert math.isclose(result['TValue'].E_C, 13915.09558491048)
 
     def test_入力値入替_R5_方式1(self, expected_inputs, expected_result_type1):
         """ 以前のプログラムと同じ計算結果になる
@@ -608,14 +609,14 @@ class Test既存計算維持_入力値切替_方式1:
         # 機器仕様の入力（入力しない or 定格能力試験の値を入力する or 定格能力試験と中間能力試験の値を入力する）
         inputs["C_A"]["input"] = 2
         # ▼ 入力する場合のみ
-        inputs["C_A"]["q_hs_rtd_C"] = 30000.0     # 定格暖房能力試験 能力 [W]
-        inputs["C_A"]["q_hs_mid_C"] = 15000.0     # 中間暖房能力試験 能力 [W]
-        inputs["C_A"]["P_hs_rtd_C"] = 8570        # 定格暖房能力試験 消費電力 [W]
-        inputs["C_A"]["P_hs_mid_C"] = 4300        # 中間暖房能力試験 消費電力 [W]
-        inputs["C_A"]["V_fan_rtd_C"] = 50.0 * 60  # 定格暖房能力試験 風量 [m3/h]
-        inputs["C_A"]["V_fan_mid_C"] = 25.0 * 60  # 中間暖房能力試験 風量 [m3/h]
-        inputs["C_A"]["P_fan_rtd_C"] = 350        # 定格暖房能力試験 室内側送風機の消費電力 [W]
-        inputs["C_A"]["P_fan_mid_C"] = 170        # 中間暖房能力試験 室内側送風機の消費電力 [W]
+        inputs["C_A"]["q_hs_rtd_C"] = 30000.0     # 定格冷房能力試験 能力 [W]
+        inputs["C_A"]["q_hs_mid_C"] = 15000.0     # 中間冷房能力試験 能力 [W]
+        inputs["C_A"]["P_hs_rtd_C"] = 8570        # 定格冷房能力試験 消費電力 [W]
+        inputs["C_A"]["P_hs_mid_C"] = 4300        # 中間冷房能力試験 消費電力 [W]
+        inputs["C_A"]["V_fan_rtd_C"] = 50.0 * 60  # 定格冷房能力試験 風量 [m3/h]
+        inputs["C_A"]["V_fan_mid_C"] = 25.0 * 60  # 中間冷房能力試験 風量 [m3/h]
+        inputs["C_A"]["P_fan_rtd_C"] = 350        # 定格冷房能力試験 室内側送風機の消費電力 [W]
+        inputs["C_A"]["P_fan_mid_C"] = 170        # 中間冷房能力試験 室内側送風機の消費電力 [W]
 
         result = calc(inputs, test_mode=True)
 
@@ -628,7 +629,7 @@ class Test既存計算維持_入力値切替_方式1:
 
         assert result['TValue'].E_H == expected_result_type1.E_H
         assert result['TValue'].E_C != expected_result_type1.E_C
-        assert result['TValue'].E_C == 19187.38971453038
+        assert math.isclose(result['TValue'].E_C, 19187.38971453038)
 
     def test_入力値入替_R6_方式1(self, expected_inputs, expected_result_type1):
         """ 以前のプログラムと同じ計算結果になる
@@ -638,14 +639,14 @@ class Test既存計算維持_入力値切替_方式1:
         inputs = copy.deepcopy(self._inputs)
         # ▼ 入力する場合のみ
         inputs["C_A"]["input"] = 2
-        inputs["C_A"]["q_hs_rtd_C"] = 27500.0     # 定格暖房能力試験 能力 [W]
-        inputs["C_A"]["q_hs_mid_C"] = 13000.0     # 中間暖房能力試験 能力 [W]
-        inputs["C_A"]["P_hs_rtd_C"] = 7100        # 定格暖房能力試験 消費電力 [W]
-        inputs["C_A"]["P_hs_mid_C"] = 3450        # 中間暖房能力試験 消費電力 [W]
-        inputs["C_A"]["V_fan_rtd_C"] = 54.0 * 60  # 定格暖房能力試験 風量 [m3/h]
-        inputs["C_A"]["V_fan_mid_C"] = 22.0 * 60  # 中間暖房能力試験 風量 [m3/h]
-        inputs["C_A"]["P_fan_rtd_C"] = 400        # 定格暖房能力試験 室内側送風機の消費電力 [W]
-        inputs["C_A"]["P_fan_mid_C"] = 210        # 中間暖房能力試験 室内側送風機の消費電力 [W]
+        inputs["C_A"]["q_hs_rtd_C"] = 27500.0     # 定格冷房能力試験 能力 [W]
+        inputs["C_A"]["q_hs_mid_C"] = 13000.0     # 中間冷房能力試験 能力 [W]
+        inputs["C_A"]["P_hs_rtd_C"] = 7100        # 定格冷房能力試験 消費電力 [W]
+        inputs["C_A"]["P_hs_mid_C"] = 3450        # 中間冷房能力試験 消費電力 [W]
+        inputs["C_A"]["V_fan_rtd_C"] = 54.0 * 60  # 定格冷房能力試験 風量 [m3/h]
+        inputs["C_A"]["V_fan_mid_C"] = 22.0 * 60  # 中間冷房能力試験 風量 [m3/h]
+        inputs["C_A"]["P_fan_rtd_C"] = 400        # 定格冷房能力試験 室内側送風機の消費電力 [W]
+        inputs["C_A"]["P_fan_mid_C"] = 210        # 中間冷房能力試験 室内側送風機の消費電力 [W]
 
         result = calc(inputs, test_mode=True)
 
@@ -656,9 +657,9 @@ class Test既存計算維持_入力値切替_方式1:
         assert result['TInput'].e_rtd_C == expected_inputs.e_rtd_C
         assert result['TInput'].e_rtd_H == expected_inputs.e_rtd_H
 
-        assert result['TValue'].E_C != expected_result_type1.E_C
-        assert result['TValue'].E_C == 19238.129853353777
         assert result['TValue'].E_H == expected_result_type1.E_H
+        assert result['TValue'].E_C != expected_result_type1.E_C
+        assert math.isclose(result['TValue'].E_C, 19238.129853353777)
 
     def test_入力値入替_HEX1(self, expected_result_type1):
         """ 以前のプログラムと同じ計算結果になる
@@ -672,6 +673,5 @@ class Test既存計算維持_入力値切替_方式1:
         result = calc(inputs, test_mode=True)
 
         assert result['TValue'].E_C == expected_result_type1.E_C
-        assert result['TValue'].E_H == 34414.79844612079
         assert result['TValue'].E_H != expected_result_type1.E_H
-
+        assert math.isclose(result['TValue'].E_H, 34414.79844612079)

--- a/tests/test_not_broken_various_inputs_type2.py
+++ b/tests/test_not_broken_various_inputs_type2.py
@@ -1,6 +1,7 @@
 import pytest
 import json
 import copy
+import math
 
 from jjjexperiment.main import calc
 
@@ -51,7 +52,7 @@ class Test既存計算維持_入力値切替_方式2:
 
         assert result['TValue'].E_C == expected_result_type2.E_C
         assert result['TValue'].E_H != expected_result_type2.E_H
-        assert result['TValue'].E_H == 40813.23277369657
+        assert math.isclose(result['TValue'].E_H, 40813.23277369657)
 
     def test_入力値入替_02(self, expected_result_type2):
         """ 以前のプログラムと同じ計算結果になる
@@ -65,7 +66,7 @@ class Test既存計算維持_入力値切替_方式2:
 
         assert result['TValue'].E_H == expected_result_type2.E_H
         assert result['TValue'].E_C != expected_result_type2.E_C
-        assert result['TValue'].E_C == 14178.967016020626
+        assert math.isclose(result['TValue'].E_C, 14178.967016020626)
 
     def test_入力値入替_03(self, expected_result_type2):
         """ 以前のプログラムと同じ計算結果になる
@@ -79,8 +80,7 @@ class Test既存計算維持_入力値切替_方式2:
 
         assert result['TValue'].E_C == expected_result_type2.E_C
         assert result['TValue'].E_H != expected_result_type2.E_H
-        assert result['TValue'].E_H == 40379.49973723975
-
+        assert math.isclose(result['TValue'].E_H, 40379.49973723975)
 
     def test_入力値入替_04(self, expected_result_type2):
         """ 以前のプログラムと同じ計算結果になる
@@ -94,7 +94,7 @@ class Test既存計算維持_入力値切替_方式2:
 
         assert result['TValue'].E_C == expected_result_type2.E_C
         assert result['TValue'].E_H != expected_result_type2.E_H
-        assert result['TValue'].E_H == 41330.46136603447
+        assert math.isclose(result['TValue'].E_H, 41330.46136603447)
 
     def test_入力値入替_05(self, expected_result_type2):
         """ 以前のプログラムと同じ計算結果になる
@@ -108,7 +108,7 @@ class Test既存計算維持_入力値切替_方式2:
 
         assert result['TValue'].E_C == expected_result_type2.E_C
         assert result['TValue'].E_H != expected_result_type2.E_H
-        assert result['TValue'].E_H == 41565.19129722995
+        assert math.isclose(result['TValue'].E_H, 41565.19129722995)
 
     def test_入力値入替_06(self, expected_result_type2):
         """ 以前のプログラムと同じ計算結果になる
@@ -120,10 +120,10 @@ class Test既存計算維持_入力値切替_方式2:
 
         result = calc(inputs, test_mode=True)
 
-        assert result['TValue'].E_C == 14785.070861211718
         assert result['TValue'].E_C != expected_result_type2.E_C
-        assert result['TValue'].E_H == 41236.578091305644
+        assert math.isclose(result['TValue'].E_C, 14785.070861211718)
         assert result['TValue'].E_H != expected_result_type2.E_H
+        assert math.isclose(result['TValue'].E_H, 41236.578091305644)
 
     def test_入力値入替_07(self, expected_result_type2):
         """ 以前のプログラムと同じ計算結果になる
@@ -137,7 +137,7 @@ class Test既存計算維持_入力値切替_方式2:
 
         assert result['TValue'].E_C == expected_result_type2.E_C
         assert result['TValue'].E_H != expected_result_type2.E_H
-        assert result['TValue'].E_H == 40775.15329048871
+        assert math.isclose(result['TValue'].E_H, 40775.15329048871)
 
     def test_入力値入替_08(self, expected_result_type2):
         """ 以前のプログラムと同じ計算結果になる
@@ -150,8 +150,8 @@ class Test既存計算維持_入力値切替_方式2:
         result = calc(inputs, test_mode=True)
 
         assert result['TValue'].E_H == expected_result_type2.E_H
-        assert result['TValue'].E_C == 14788.362569150617
         assert result['TValue'].E_C != expected_result_type2.E_C
+        assert math.isclose(result['TValue'].E_C, 14788.362569150617)
 
     def test_入力値入替_09(self, expected_result_type2):
         """ 以前のプログラムと同じ計算結果になる
@@ -165,7 +165,7 @@ class Test既存計算維持_入力値切替_方式2:
 
         assert result['TValue'].E_C == expected_result_type2.E_C
         assert result['TValue'].E_H != expected_result_type2.E_H
-        assert result['TValue'].E_H == 40228.03332635408
+        assert math.isclose(result['TValue'].E_H, 40228.03332635408)
 
     def test_入力値入替_10(self, expected_result_type2):
         """ 以前のプログラムと同じ計算結果になる
@@ -179,7 +179,7 @@ class Test既存計算維持_入力値切替_方式2:
 
         assert result['TValue'].E_C == expected_result_type2.E_C
         assert result['TValue'].E_H != expected_result_type2.E_H
-        assert result['TValue'].E_H == 40925.918843796484
+        assert math.isclose(result['TValue'].E_H, 40925.918843796484)
 
     def test_入力値入替_11(self, expected_result_type2):
         """ 以前のプログラムと同じ計算結果になる
@@ -191,9 +191,9 @@ class Test既存計算維持_入力値切替_方式2:
 
         result = calc(inputs, test_mode=True)
 
-        assert result['TValue'].E_H != expected_result_type2.E_H
-        assert result['TValue'].E_H == 40481.81864211065
         assert result['TValue'].E_C == expected_result_type2.E_C
+        assert result['TValue'].E_H != expected_result_type2.E_H
+        assert math.isclose(result['TValue'].E_H, 40481.81864211065)
 
     def test_入力値入替_12(self, expected_result_type2):
         """ 以前のプログラムと同じ計算結果になる
@@ -207,7 +207,7 @@ class Test既存計算維持_入力値切替_方式2:
 
         assert result['TValue'].E_H == expected_result_type2.E_H
         assert result['TValue'].E_C != expected_result_type2.E_C
-        assert result['TValue'].E_C == 12824.79767377771
+        assert math.isclose(result['TValue'].E_C, 12824.79767377771)
 
     def test_入力値入替_13(self, expected_result_type2):
         """ 以前のプログラムと同じ計算結果になる
@@ -219,10 +219,10 @@ class Test既存計算維持_入力値切替_方式2:
 
         result = calc(inputs, test_mode=True)
 
-        assert result['TValue'].E_C != expected_result_type2.E_C
-        assert result['TValue'].E_C == 17002.04875326623
         assert result['TValue'].E_H != expected_result_type2.E_H
-        assert result['TValue'].E_H == 43487.16595274875
+        assert math.isclose(result['TValue'].E_H, 43487.16595274875)
+        assert result['TValue'].E_C != expected_result_type2.E_C
+        assert math.isclose(result['TValue'].E_C, 17002.04875326623)
 
     def test_入力値入替_14(self, expected_result_type2):
         """ 以前のプログラムと同じ計算結果になる
@@ -234,10 +234,10 @@ class Test既存計算維持_入力値切替_方式2:
 
         result = calc(inputs, test_mode=True)
 
-        assert result['TValue'].E_H == 40822.38807655774
         assert result['TValue'].E_H != expected_result_type2.E_H
-        assert result['TValue'].E_C == 14184.472397667007
+        assert math.isclose(result['TValue'].E_H, 40822.38807655774)
         assert result['TValue'].E_C != expected_result_type2.E_C
+        assert math.isclose(result['TValue'].E_C, 14184.472397667007)
 
     def test_入力値入替_15(self, expected_result_type2):
         """ 以前のプログラムと同じ計算結果になる
@@ -250,9 +250,9 @@ class Test既存計算維持_入力値切替_方式2:
         result = calc(inputs, test_mode=True)
 
         assert result['TValue'].E_H != expected_result_type2.E_H
-        assert result['TValue'].E_H == 47702.33872845253
+        assert math.isclose(result['TValue'].E_H, 47702.33872845253)
         assert result['TValue'].E_C != expected_result_type2.E_C
-        assert result['TValue'].E_C == 22378.09180122358
+        assert math.isclose(result['TValue'].E_C, 22378.09180122358)
 
     def test_入力値入替_16(self, expected_result_type2):
         """ 以前のプログラムと同じ計算結果になる
@@ -265,9 +265,9 @@ class Test既存計算維持_入力値切替_方式2:
         result = calc(inputs, test_mode=True)
 
         assert result['TValue'].E_H != expected_result_type2.E_H
-        assert result['TValue'].E_H == 58567.764449747614
+        assert math.isclose(result['TValue'].E_H, 58567.764449747614)
         assert result['TValue'].E_C != expected_result_type2.E_C
-        assert result['TValue'].E_C == 25009.231072133218
+        assert math.isclose(result['TValue'].E_C, 25009.231072133218)
 
     def test_入力値入替_17(self, expected_result_type2):
         """ 以前のプログラムと同じ計算結果になる
@@ -279,10 +279,10 @@ class Test既存計算維持_入力値切替_方式2:
 
         result = calc(inputs, test_mode=True)
 
-        assert result['TValue'].E_H == 174560.6036239345
         assert result['TValue'].E_H != expected_result_type2.E_H
-        assert result['TValue'].E_C == 2884.2632006293015
+        assert math.isclose(result['TValue'].E_H, 174560.6036239345)
         assert result['TValue'].E_C != expected_result_type2.E_C
+        assert math.isclose(result['TValue'].E_C, 2884.2632006293015)
 
     def test_入力値入替_18(self, expected_result_type2):
         """ 以前のプログラムと同じ計算結果になる
@@ -295,9 +295,9 @@ class Test既存計算維持_入力値切替_方式2:
         result = calc(inputs, test_mode=True)
 
         assert result['TValue'].E_H != expected_result_type2.E_H
-        assert result['TValue'].E_H == 45819.9093469388
+        assert math.isclose(result['TValue'].E_H, 45819.9093469388)
         assert result['TValue'].E_C != expected_result_type2.E_C
-        assert result['TValue'].E_C == 15119.878587850431
+        assert math.isclose(result['TValue'].E_C, 15119.878587850431)
 
     def test_入力値入替_19(self, expected_result_type2):
         """ 以前のプログラムと同じ計算結果になる
@@ -310,9 +310,9 @@ class Test既存計算維持_入力値切替_方式2:
         result = calc(inputs, test_mode=True)
 
         assert result['TValue'].E_H != expected_result_type2.E_H
-        assert result['TValue'].E_H == 51145.64313095035
+        assert math.isclose(result['TValue'].E_H, 51145.64313095035)
         assert result['TValue'].E_C != expected_result_type2.E_C
-        assert result['TValue'].E_C == 14057.66109771598
+        assert math.isclose(result['TValue'].E_C, 14057.66109771598)
 
     def test_入力値入替_20(self, expected_result_type2):
         """ 以前のプログラムと同じ計算結果になる
@@ -325,8 +325,8 @@ class Test既存計算維持_入力値切替_方式2:
         result = calc(inputs, test_mode=True)
 
         assert result['TValue'].E_H == expected_result_type2.E_H
-        assert result['TValue'].E_C == 16690.55292080024
         assert result['TValue'].E_C != expected_result_type2.E_C
+        assert math.isclose(result['TValue'].E_C, 16690.55292080024)
 
     def test_入力値入替_21(self, expected_result_type2):
         """ 以前のプログラムと同じ計算結果になる
@@ -339,8 +339,8 @@ class Test既存計算維持_入力値切替_方式2:
         result = calc(inputs, test_mode=True)
 
         assert result['TValue'].E_C == expected_result_type2.E_C
-        assert result['TValue'].E_H == 43202.66151700742
         assert result['TValue'].E_H != expected_result_type2.E_H
+        assert math.isclose(result['TValue'].E_H, 43202.66151700742)
 
     def test_入力値入替_22(self, expected_result_type2):
         """ 以前のプログラムと同じ計算結果になる
@@ -352,10 +352,10 @@ class Test既存計算維持_入力値切替_方式2:
 
         result = calc(inputs, test_mode=True)
 
-        assert result['TValue'].E_H == 38306.56455225713
         assert result['TValue'].E_H != expected_result_type2.E_H
-        assert result['TValue'].E_C == 12647.872661178222
+        assert math.isclose(result['TValue'].E_H, 38306.56455225713)
         assert result['TValue'].E_C != expected_result_type2.E_C
+        assert math.isclose(result['TValue'].E_C, 12647.872661178222)
 
     def test_入力値入替_23(self, expected_result_type2):
         """ 以前のプログラムと同じ計算結果になる
@@ -396,9 +396,9 @@ class Test既存計算維持_入力値切替_方式2:
         result = calc(inputs, test_mode=True)
 
         assert result['TValue'].E_H != expected_result_type2.E_H
-        assert result['TValue'].E_H == 67493.42767621638
+        assert math.isclose(result['TValue'].E_H, 67493.42767621638)
         assert result['TValue'].E_C != expected_result_type2.E_C
-        assert result['TValue'].E_C == 18872.3162663047
+        assert math.isclose(result['TValue'].E_C, 18872.3162663047)
 
     def test_入力値入替_26(self, expected_result_type2):
         """ 以前のプログラムと同じ計算結果になる
@@ -426,7 +426,7 @@ class Test既存計算維持_入力値切替_方式2:
 
         assert result['TValue'].E_C == expected_result_type2.E_C
         assert result['TValue'].E_H != expected_result_type2.E_H
-        assert result['TValue'].E_H == 41606.24726343731
+        assert math.isclose(result['TValue'].E_H, 41606.24726343731)
 
     def test_入力値入替_H1(self, expected_result_type2):
         """ 以前のプログラムと同じ計算結果になる
@@ -439,8 +439,8 @@ class Test既存計算維持_入力値切替_方式2:
         result = calc(inputs, test_mode=True)
 
         assert result['TValue'].E_C == expected_result_type2.E_C
-        assert result['TValue'].E_H == 38430.15407789486
         assert result['TValue'].E_H != expected_result_type2.E_H
+        assert math.isclose(result['TValue'].E_H, 38430.15407789486)
 
     def test_入力値入替_H2(self, expected_result_type2):
         """ 以前のプログラムと同じ計算結果になる
@@ -453,8 +453,8 @@ class Test既存計算維持_入力値切替_方式2:
         result = calc(inputs, test_mode=True)
 
         assert result['TValue'].E_C == expected_result_type2.E_C
-        assert result['TValue'].E_H == 39572.83185804524
         assert result['TValue'].E_H != expected_result_type2.E_H
+        assert math.isclose(result['TValue'].E_H, 39572.83185804524)
 
     def test_入力値入替_H3(self, expected_result_type2):
         """ 以前のプログラムと同じ計算結果になる
@@ -468,7 +468,7 @@ class Test既存計算維持_入力値切替_方式2:
 
         assert result['TValue'].E_C == expected_result_type2.E_C
         assert result['TValue'].E_H != expected_result_type2.E_H
-        assert result['TValue'].E_H == 41467.93507466678
+        assert math.isclose(result['TValue'].E_H, 41467.93507466678)
 
     def test_入力値入替_H4(self, expected_result_type2):
         """ 以前のプログラムと同じ計算結果になる
@@ -482,10 +482,10 @@ class Test既存計算維持_入力値切替_方式2:
         result = calc(inputs, test_mode=True)
 
         assert result['TValue'].E_C == expected_result_type2.E_C
-        assert result['TValue'].E_H == 40896.18678654383
         assert result['TValue'].E_H != expected_result_type2.E_H
+        assert math.isclose(result['TValue'].E_H, 40896.18678654383)
 
-    def test_入力値入替_H5_方式1(self, expected_inputs, expected_result_type2):
+    def test_入力値入替_H5_方式2(self, expected_inputs, expected_result_type2):
         """ 以前のプログラムと同じ計算結果になる
             暖房の機器仕様を入力する1
         """
@@ -525,11 +525,11 @@ class Test既存計算維持_入力値切替_方式2:
         assert result['TInput'].e_rtd_H == expected_inputs.e_rtd_H
         assert result['TInput'].e_rtd_C == expected_inputs.e_rtd_C
 
-        assert result['TValue'].E_H != expected_result_type2.E_H
-        assert result['TValue'].E_H == 31577.30541426199
         assert result['TValue'].E_C == expected_result_type2.E_C
+        assert result['TValue'].E_H != expected_result_type2.E_H
+        assert math.isclose(result['TValue'].E_H, 31577.30541426199)
 
-    def test_入力値入替_H6_方式1(self, expected_inputs, expected_result_type2):
+    def test_入力値入替_H6_方式2(self, expected_inputs, expected_result_type2):
         """ 以前のプログラムと同じ計算結果になる
             暖房の機器仕様を入力する2
         """
@@ -562,15 +562,21 @@ class Test既存計算維持_入力値切替_方式2:
 
         result = calc(inputs, test_mode=True)
 
-        assert result['TInput'].q_max_H == 4700.0
         assert result['TInput'].q_max_C == expected_inputs.q_max_C
-        assert result['TInput'].q_rtd_H == 3600.0
-        assert result['TInput'].q_rtd_C == expected_inputs.q_rtd_C
-        assert result['TInput'].e_rtd_H == 3.93
-        assert result['TInput'].e_rtd_C == expected_inputs.e_rtd_C
+        assert result['TInput'].q_max_H != expected_inputs.q_max_H
+        assert math.isclose(result['TInput'].q_max_H, 4700.0)
 
-        assert result['TValue'].E_H == 40540.29726496144
+        assert result['TInput'].q_rtd_C == expected_inputs.q_rtd_C
+        assert result['TInput'].q_rtd_H != expected_inputs.q_rtd_H
+        assert math.isclose(result['TInput'].q_rtd_H, 3600.0)
+
+        assert result['TInput'].e_rtd_C == expected_inputs.e_rtd_C
+        assert result['TInput'].e_rtd_H != expected_inputs.e_rtd_H
+        assert math.isclose(result['TInput'].e_rtd_H, 3.93)
+
         assert result['TValue'].E_C == expected_result_type2.E_C
+        assert result['TValue'].E_H != expected_result_type2.E_H
+        assert math.isclose(result['TValue'].E_H, 40540.29726496144)
 
     def test_入力値入替_R1(self, expected_result_type2):
         """ 以前のプログラムと同じ計算結果になる
@@ -584,7 +590,7 @@ class Test既存計算維持_入力値切替_方式2:
 
         assert result['TValue'].E_H == expected_result_type2.E_H
         assert result['TValue'].E_C != expected_result_type2.E_C
-        assert result['TValue'].E_C == 14407.53084233618
+        assert math.isclose(result['TValue'].E_C, 14407.53084233618)
 
     def test_入力値入替_R2(self, expected_result_type2):
         """ 以前のプログラムと同じ計算結果になる
@@ -598,7 +604,7 @@ class Test既存計算維持_入力値切替_方式2:
 
         assert result['TValue'].E_H == expected_result_type2.E_H
         assert result['TValue'].E_C != expected_result_type2.E_C
-        assert result['TValue'].E_C == 12126.41287275799
+        assert math.isclose(result['TValue'].E_C, 12126.41287275799)
 
     def test_入力値入替_R3(self, expected_result_type2):
         """ 以前のプログラムと同じ計算結果になる
@@ -611,8 +617,8 @@ class Test既存計算維持_入力値切替_方式2:
         result = calc(inputs, test_mode=True)
 
         assert result['TValue'].E_H == expected_result_type2.E_H
-        assert result['TValue'].E_C == 15141.75913372107
         assert result['TValue'].E_C != expected_result_type2.E_C
+        assert math.isclose(result['TValue'].E_C, 15141.75913372107)
 
     def test_入力値入替_R4(self, expected_result_type2):
         """ 以前のプログラムと同じ計算結果になる
@@ -626,10 +632,10 @@ class Test既存計算維持_入力値切替_方式2:
         result = calc(inputs, test_mode=True)
 
         assert result['TValue'].E_H == expected_result_type2.E_H
-        assert result['TValue'].E_C == 16296.897277400154
         assert result['TValue'].E_C != expected_result_type2.E_C
+        assert math.isclose(result['TValue'].E_C, 16296.897277400154)
 
-    def test_入力値入替_R5_方式1(self, expected_result_type2, expected_inputs):
+    def test_入力値入替_R5_方式2(self, expected_result_type2, expected_inputs):
         """ 以前のプログラムと同じ計算結果になる
             冷房の機器仕様を入力する1
         """
@@ -669,11 +675,11 @@ class Test既存計算維持_入力値切替_方式2:
         assert result['TInput'].e_rtd_C == expected_inputs.e_rtd_C
         assert result['TInput'].e_rtd_H == expected_inputs.e_rtd_H
 
-        assert result['TValue'].E_H != expected_result_type2.E_C
+        assert result['TValue'].E_H == expected_result_type2.E_H
         assert result['TValue'].E_C != expected_result_type2.E_C
-        assert result['TValue'].E_C == 14046.978599922277
+        assert math.isclose(result['TValue'].E_C, 14046.978599922277)
 
-    def test_入力値入替_R6_方式1(self, expected_result_type2):
+    def test_入力値入替_R6_方式2(self, expected_result_type2):
         """ 以前のプログラムと同じ計算結果になる
             冷房の機器仕様を入力する2
         """
@@ -707,15 +713,15 @@ class Test既存計算維持_入力値切替_方式2:
         result = calc(inputs, test_mode=True)
 
         # TODO: 暖房についても結果が変わるのは大丈夫?
-        assert result['TInput'].q_rtd_C == 2800.0
-        assert result['TInput'].q_rtd_H == 3300.1000000000004
-        assert result['TInput'].q_max_C == 3400.0
-        assert result['TInput'].q_max_H == 5569.280000000001
-        assert result['TInput'].e_rtd_C == 2.59
-        assert result['TInput'].e_rtd_H == 3.6543
+        assert math.isclose(result['TInput'].q_rtd_C, 2800.0)
+        assert math.isclose(result['TInput'].q_rtd_H, 3300.1000000000004)
+        assert math.isclose(result['TInput'].q_max_C, 3400.0)
+        assert math.isclose(result['TInput'].q_max_H, 5569.280000000001)
+        assert math.isclose(result['TInput'].e_rtd_C, 2.59)
+        assert math.isclose(result['TInput'].e_rtd_H, 3.6543)
 
-        assert result['TValue'].E_C == 21336.043883848488
-        assert result['TValue'].E_H == 46940.16551587674
+        assert math.isclose(result['TValue'].E_C, 21336.043883848488)
+        assert math.isclose(result['TValue'].E_H, 46940.16551587674)
 
     def test_入力値入替_HEX1(self, expected_result_type2):
         """ 以前のプログラムと同じ計算結果になる
@@ -729,5 +735,5 @@ class Test既存計算維持_入力値切替_方式2:
         result = calc(inputs, test_mode=True)
 
         assert result['TValue'].E_C == expected_result_type2.E_C
-        assert result['TValue'].E_H == 38022.75810040755
         assert result['TValue'].E_H != expected_result_type2.E_H
+        assert math.isclose(result['TValue'].E_H, 38022.75810040755)

--- a/tests/test_type3_logics.py
+++ b/tests/test_type3_logics.py
@@ -229,15 +229,15 @@ class Test風量特性_熱源機_低出力:
 
     def test_暖房時_指定定数(self):
         ii = np.where(self._H == True)[0]
-        assert np.all(self._sut[ii] == consts.airvolume_coeff_minimum)
+        assert np.all(self._sut[ii] == consts.airvolume_minimum)
 
     def test_冷房時_指定定数(self):
         ii = np.where(self._C == True)[0]
-        assert np.all(self._sut[ii] == consts.airvolume_coeff_minimum)
+        assert np.all(self._sut[ii] == consts.airvolume_minimum)
 
     def test_中間期_常に指定定数(self):
         ii = np.where(self._M == True)[0]
-        assert np.all(self._sut[ii] == consts.airvolume_coeff_minimum)
+        assert np.all(self._sut[ii] == consts.airvolume_minimum)
 
 class Test風量特性_熱源機_高出力:
 
@@ -277,7 +277,7 @@ class Test風量特性_熱源機_高出力:
 
     def test_中間期_常に指定定数(self):
         ii = np.where(self._M == True)[0]
-        assert np.all(self._sut[ii] == consts.airvolume_coeff_minimum)
+        assert np.all(self._sut[ii] == consts.airvolume_minimum)
 
 
 def prepare_args_for_calc_Q_UT_A() -> dict:

--- a/tests/test_type3_logics.py
+++ b/tests/test_type3_logics.py
@@ -20,11 +20,12 @@ INPUT_PATH = './tests/inputs/default_testinput.json'
 
 class Testコイル特性:
 
-    expected_T1T2 = {
+    _expected_T1T2 = {
         'A_f_hex': 0.23559,  # 仕様書より
         'A_e_hex': 6.396,    # 仕様書より
     }
-    expected_T3 = {
+
+    _expected_T3 = {
         'A_f_hex_upper': 0.3,  # 仕様書より
         'A_f_hex_lower': 0.2,  # 仕様書より
         'A_f_hex_custom': 0.23456,  # ユーザーの独自入力を想定
@@ -35,61 +36,85 @@ class Testコイル特性:
 
     def test_有効面積_方式1_定格低(self):
         """ 定格能力 5.6 kW 未満で 仕様書通り """
-        assert self.expected_T1T2['A_f_hex'] == get_A_f_hex(PROCESS_TYPE_1, 5500)
-        assert self.expected_T1T2['A_e_hex'] == get_A_e_hex(PROCESS_TYPE_1, 5500)
+        assert self._expected_T1T2['A_f_hex'] == get_A_f_hex(PROCESS_TYPE_1, 5500)
+        assert self._expected_T1T2['A_e_hex'] == get_A_e_hex(PROCESS_TYPE_1, 5500)
     def test_有効面積_方式1_定格BVA(self):
         """ 定格能力 5.6 kW 丁度で 仕様書通り """
-        assert self.expected_T1T2['A_f_hex'] == get_A_f_hex(PROCESS_TYPE_1, 5600)
-        assert self.expected_T1T2['A_e_hex'] == get_A_e_hex(PROCESS_TYPE_1, 5600)
+        assert self._expected_T1T2['A_f_hex'] == get_A_f_hex(PROCESS_TYPE_1, 5600)
+        assert self._expected_T1T2['A_e_hex'] == get_A_e_hex(PROCESS_TYPE_1, 5600)
     def test_有効面積_方式1_定格高(self):
         """ 定格能力 5.6 kW 以上で 仕様書通り """
-        assert self.expected_T1T2['A_f_hex'] == get_A_f_hex(PROCESS_TYPE_1, 5700)
-        assert self.expected_T1T2['A_e_hex'] == get_A_e_hex(PROCESS_TYPE_1, 5700)
+        assert self._expected_T1T2['A_f_hex'] == get_A_f_hex(PROCESS_TYPE_1, 5700)
+        assert self._expected_T1T2['A_e_hex'] == get_A_e_hex(PROCESS_TYPE_1, 5700)
 
     def test_有効面積_方式2_定格低(self):
         """ 定格能力 5.6 kW 未満で 仕様書通り """
-        assert self.expected_T1T2['A_f_hex'] == get_A_f_hex(PROCESS_TYPE_2, 5500)
-        assert self.expected_T1T2['A_e_hex'] == get_A_e_hex(PROCESS_TYPE_2, 5500)
+        assert self._expected_T1T2['A_f_hex'] == get_A_f_hex(PROCESS_TYPE_2, 5500)
+        assert self._expected_T1T2['A_e_hex'] == get_A_e_hex(PROCESS_TYPE_2, 5500)
     def test_有効面積_方式2_定格BVA(self):
         """ 定格能力 5.6 kW 丁度で 仕様書通り """
-        assert self.expected_T1T2['A_f_hex'] == get_A_f_hex(PROCESS_TYPE_2, 5600)
-        assert self.expected_T1T2['A_e_hex'] == get_A_e_hex(PROCESS_TYPE_2, 5600)
+        assert self._expected_T1T2['A_f_hex'] == get_A_f_hex(PROCESS_TYPE_2, 5600)
+        assert self._expected_T1T2['A_e_hex'] == get_A_e_hex(PROCESS_TYPE_2, 5600)
     def test_有効面積_方式2_定格高(self):
         """ 定格能力 5.6 kW 以上で 仕様書通り """
-        assert self.expected_T1T2['A_f_hex'] == get_A_f_hex(PROCESS_TYPE_2, 5700)
-        assert self.expected_T1T2['A_e_hex'] == get_A_e_hex(PROCESS_TYPE_2, 5700)
+        assert self._expected_T1T2['A_f_hex'] == get_A_f_hex(PROCESS_TYPE_2, 5700)
+        assert self._expected_T1T2['A_e_hex'] == get_A_e_hex(PROCESS_TYPE_2, 5700)
 
     def test_有効面積_方式3_定格低(self):
         """ 定格能力 5.6 kW 未満で 仕様書通り """
-        assert self.expected_T3['A_f_hex_lower'] == get_A_f_hex(PROCESS_TYPE_3, 5500)
-        assert self.expected_T3['A_e_hex_lower'] == get_A_e_hex(PROCESS_TYPE_3, 5500)
+        assert self._expected_T3['A_f_hex_lower'] == get_A_f_hex(PROCESS_TYPE_3, 5500)
+        assert self._expected_T3['A_e_hex_lower'] == get_A_e_hex(PROCESS_TYPE_3, 5500)
     def test_有効面積_方式3_定格BVA(self):
         """ 定格能力 5.6 kW 丁度で 仕様書通り """
-        assert self.expected_T3['A_f_hex_upper'] == get_A_f_hex(PROCESS_TYPE_3, 5600)
-        assert self.expected_T3['A_e_hex_upper'] == get_A_e_hex(PROCESS_TYPE_3, 5600)
+        assert self._expected_T3['A_f_hex_upper'] == get_A_f_hex(PROCESS_TYPE_3, 5600)
+        assert self._expected_T3['A_e_hex_upper'] == get_A_e_hex(PROCESS_TYPE_3, 5600)
     def test_有効面積_方式3_定格高(self):
         """ 定格能力 5.6 kW 以上で 仕様書通り """
-        assert self.expected_T3['A_f_hex_upper'] == get_A_f_hex(PROCESS_TYPE_3, 5700)
-        assert self.expected_T3['A_e_hex_upper'] == get_A_e_hex(PROCESS_TYPE_3, 5700)
+        assert self._expected_T3['A_f_hex_upper'] == get_A_f_hex(PROCESS_TYPE_3, 5700)
+        assert self._expected_T3['A_e_hex_upper'] == get_A_e_hex(PROCESS_TYPE_3, 5700)
+
+
+class Testコイル特性_方式3_ユーザー独自値:
+    """ 潜熱評価モデル時のコイル特性の係数はユーザーの独自値が設定可能としています
+    """
+    _custom_values = {
+        'H_A': {
+            'A_f_hex_small': 0.12345,  # ユーザーの独自入力を想定
+            'A_e_hex_small': 6.66666,  # ユーザーの独自入力を想定
+            'A_f_hex_large': 0.23456,  # ユーザーの独自入力を想定
+            'A_e_hex_large': 7.77777,  # ユーザーの独自入力を想定
+        }
+    }
+    _default_values = {
+        'H_A': {
+            'A_f_hex_small': 0.2,   # 規定値
+            'A_e_hex_small': 6.2,   # 規定値
+            'A_f_hex_large': 0.3,   # 規定値
+            'A_e_hex_large': 10.6,  # 規定値
+        }
+    }
+    @classmethod
+    def setup_class(cls):
+        """ ユーザーカスタム値を適用する """
+        consts.set_constants(cls._custom_values)
+
+    @classmethod
+    def teardown_class(cls):
+        """ ユーザーカスタム値をデフォルト値に戻す """
+        consts.set_constants(cls._default_values)
 
     def test_有効面積_方式3_定格低_上書き(self):
         """ 定格能力 5.6 kW 未満で 仕様書通り """
-        consts.A_f_hex_small_H = self.expected_T3['A_f_hex_custom']
-        consts.A_e_hex_small_H = self.expected_T3['A_e_hex_custom']
-        assert self.expected_T3['A_f_hex_custom'] == get_A_f_hex(PROCESS_TYPE_3, 5500)
-        assert self.expected_T3['A_e_hex_custom'] == get_A_e_hex(PROCESS_TYPE_3, 5500)
+        assert self._custom_values['H_A']['A_f_hex_small'] == get_A_f_hex(PROCESS_TYPE_3, 5500)
+        assert self._custom_values['H_A']['A_e_hex_small'] == get_A_e_hex(PROCESS_TYPE_3, 5500)
     def test_有効面積_方式3_定格BVA_上書き(self):
         """ 定格能力 5.6 kW 丁度で 仕様書通り """
-        consts.A_f_hex_large_H = self.expected_T3['A_f_hex_custom']
-        consts.A_e_hex_large_H = self.expected_T3['A_e_hex_custom']
-        assert self.expected_T3['A_f_hex_custom'] == get_A_f_hex(PROCESS_TYPE_3, 5600)
-        assert self.expected_T3['A_e_hex_custom'] == get_A_e_hex(PROCESS_TYPE_3, 5600)
+        assert self._custom_values['H_A']['A_f_hex_large'] == get_A_f_hex(PROCESS_TYPE_3, 5600)
+        assert self._custom_values['H_A']['A_e_hex_large'] == get_A_e_hex(PROCESS_TYPE_3, 5600)
     def test_有効面積_方式3_定格高_上書き(self):
         """ 定格能力 5.6 kW 以上で 仕様書通り """
-        consts.A_f_hex_large_H = self.expected_T3['A_f_hex_custom']
-        consts.A_e_hex_large_H = self.expected_T3['A_e_hex_custom']
-        assert self.expected_T3['A_f_hex_custom'] == get_A_f_hex(PROCESS_TYPE_3, 5700)
-        assert self.expected_T3['A_e_hex_custom'] == get_A_e_hex(PROCESS_TYPE_3, 5700)
+        assert self._custom_values['H_A']['A_f_hex_large'] == get_A_f_hex(PROCESS_TYPE_3, 5700)
+        assert self._custom_values['H_A']['A_e_hex_large'] == get_A_e_hex(PROCESS_TYPE_3, 5700)
 
 class Test熱伝達特性_冷房:
 


### PR DESCRIPTION
m3/h で返すべきところを、km3/h で返されていたので修正しました。
その他、テストの追従コードを含みます。