### PR TITLE
電中研の循環ファンの消費電力が他方式より低い問題への対応

### DIFF
--- a/jjjexperiment/calc.py
+++ b/jjjexperiment/calc.py
@@ -806,6 +806,7 @@ def calc_E_E_H_d_t(
                                        where=COP_H_d_t!=0)  # kWh
 
             # (37) 送風機の付加分（kWh/h）
+            # NOTE: 求めたいのは循環ファンなので P_rac_fan ではなく P_fan を使用する
             E_E_fan_H_d_t = dc_a.get_E_E_fan_H_d_t(type, P_fan_rtd_H, V_hs_vent_d_t, V_hs_supply_d_t, V_hs_dsgn_H, q_hs_H_d_t, f_SFP_H)
 
             df_output_denchuH = pd.DataFrame(index = pd.date_range(

--- a/jjjexperiment/calc.py
+++ b/jjjexperiment/calc.py
@@ -805,8 +805,8 @@ def calc_E_E_H_d_t(
                                        out=np.zeros_like(q_hs_H_d_t),
                                        where=COP_H_d_t!=0)  # kWh
 
-            E_E_fan_H_d_t = np.zeros(24 * 365)
-            E_E_fan_H_d_t[q_hs_H_d_t > 0] = P_rac_fan_rtd_H/1000 * 1
+            # (37) 送風機の付加分（kWh/h）
+            E_E_fan_H_d_t = dc_a.get_E_E_fan_H_d_t(type, P_fan_rtd_H, V_hs_vent_d_t, V_hs_supply_d_t, V_hs_dsgn_H, q_hs_H_d_t, f_SFP_H)
 
             df_output_denchuH = pd.DataFrame(index = pd.date_range(
                 datetime(2023,1,1,1,0,0), datetime(2024,1,1,0,0,0), freq='h'))
@@ -895,6 +895,7 @@ def calc_E_E_C_d_t(
 
         # (38) 送風機の付加分 (kWh/h)
         E_E_fan_C_d_t = dc_a.get_E_E_fan_C_d_t(type, P_fan_rtd_C, V_hs_vent_d_t, V_hs_supply_d_t, V_hs_dsgn_C, q_hs_C_d_t, f_SFP_C)
+
         # (6) 圧縮機の分
         E_E_comp_C_d_t = dc_a.get_E_E_comp_C_d_t(
                             q_hs_C_d_t,
@@ -946,8 +947,8 @@ def calc_E_E_C_d_t(
                                 out=np.zeros_like(q_hs_C_d_t),
                                 where=COP_C_d_t!=0)  # kWh
 
-            E_E_fan_C_d_t = np.zeros(24 * 365)
-            E_E_fan_C_d_t[q_hs_C_d_t > 0] = P_rac_fan_rtd_C/1000 * 1
+            # (38) 送風機の付加分 (kWh/h)
+            E_E_fan_C_d_t = dc_a.get_E_E_fan_C_d_t(type, P_fan_rtd_C, V_hs_vent_d_t, V_hs_supply_d_t, V_hs_dsgn_C, q_hs_C_d_t, f_SFP_C)
 
             df_output_denchuC = pd.DataFrame(index = pd.date_range(
                 datetime(2023,1,1,1,0,0), datetime(2024,1,1,0,0,0), freq='h'))
@@ -961,6 +962,8 @@ def calc_E_E_C_d_t(
             )
             df_output_denchuC.to_csv(case_name + version_info() + '_denchu_C_output.csv', encoding='cp932')  # =Shift_JIS
 
+        _logger.NDdebug("E_E_CRAC_C_d_t", E_E_CRAC_C_d_t)
+        _logger.NDdebug("E_E_fan_C_d_t", E_E_fan_C_d_t)
         E_E_C_d_t = E_E_CRAC_C_d_t + E_E_fan_C_d_t  # (2)
 
     else:

--- a/jjjexperiment/calc.py
+++ b/jjjexperiment/calc.py
@@ -27,7 +27,7 @@ def version_info() -> str:
     """
     # NOTE: subprocessモジュールによるコミット履歴からの生成は \
     # ipynb 環境では正常に動作しませんでした(returned no-zero exit status 128.)
-    return '_20231011'
+    return '_20231020'
 
 def calc_Q_UT_A(case_name, A_A, A_MR, A_OR, A_env, mu_H, mu_C, q_hs_rtd_H, q_hs_rtd_C, q_rtd_H, q_rtd_C, q_max_H, q_max_C, V_hs_dsgn_H, V_hs_dsgn_C, Q,
             VAV, general_ventilation, hs_CAV, duct_insulation, region, L_H_d_t_i, L_CS_d_t_i, L_CL_d_t_i,
@@ -809,6 +809,11 @@ def calc_E_E_H_d_t(
             # NOTE: 求めたいのは循環ファンなので P_rac_fan ではなく P_fan を使用する
             E_E_fan_H_d_t = dc_a.get_E_E_fan_H_d_t(type, P_fan_rtd_H, V_hs_vent_d_t, V_hs_supply_d_t, V_hs_dsgn_H, q_hs_H_d_t, f_SFP_H)
 
+            _logger.NDdebug("V_hs_vent_d_t", V_hs_vent_d_t)
+            _logger.NDdebug("V_hs_supply_d_t", V_hs_supply_d_t)
+            _logger.NDdebug("q_hs_H_d_t", q_hs_H_d_t)
+            _logger.NDdebug("E_E_fan_H_d_t", E_E_fan_H_d_t)
+
             df_output_denchuH = pd.DataFrame(index = pd.date_range(
                 datetime(2023,1,1,1,0,0), datetime(2024,1,1,0,0,0), freq='h'))
 
@@ -962,6 +967,11 @@ def calc_E_E_C_d_t(
                 E_E_C_d_t = E_E_CRAC_C_d_t + E_E_fan_C_d_t  # kW
             )
             df_output_denchuC.to_csv(case_name + version_info() + '_denchu_C_output.csv', encoding='cp932')  # =Shift_JIS
+
+            _logger.NDdebug("V_hs_vent_d_t", V_hs_vent_d_t)
+            _logger.NDdebug("V_hs_supply_d_t", V_hs_supply_d_t)
+            _logger.NDdebug("q_hs_H_d_t", q_hs_C_d_t)
+            _logger.NDdebug("E_E_fan_H_d_t", E_E_fan_C_d_t)
 
         _logger.NDdebug("E_E_CRAC_C_d_t", E_E_CRAC_C_d_t)
         _logger.NDdebug("E_E_fan_C_d_t", E_E_fan_C_d_t)

--- a/jjjexperiment/calc.py
+++ b/jjjexperiment/calc.py
@@ -809,11 +809,6 @@ def calc_E_E_H_d_t(
             # NOTE: 求めたいのは循環ファンなので P_rac_fan ではなく P_fan を使用する
             E_E_fan_H_d_t = dc_a.get_E_E_fan_H_d_t(type, P_fan_rtd_H, V_hs_vent_d_t, V_hs_supply_d_t, V_hs_dsgn_H, q_hs_H_d_t, f_SFP_H)
 
-            _logger.NDdebug("V_hs_vent_d_t", V_hs_vent_d_t)
-            _logger.NDdebug("V_hs_supply_d_t", V_hs_supply_d_t)
-            _logger.NDdebug("q_hs_H_d_t", q_hs_H_d_t)
-            _logger.NDdebug("E_E_fan_H_d_t", E_E_fan_H_d_t)
-
             df_output_denchuH = pd.DataFrame(index = pd.date_range(
                 datetime(2023,1,1,1,0,0), datetime(2024,1,1,0,0,0), freq='h'))
 
@@ -967,11 +962,6 @@ def calc_E_E_C_d_t(
                 E_E_C_d_t = E_E_CRAC_C_d_t + E_E_fan_C_d_t  # kW
             )
             df_output_denchuC.to_csv(case_name + version_info() + '_denchu_C_output.csv', encoding='cp932')  # =Shift_JIS
-
-            _logger.NDdebug("V_hs_vent_d_t", V_hs_vent_d_t)
-            _logger.NDdebug("V_hs_supply_d_t", V_hs_supply_d_t)
-            _logger.NDdebug("q_hs_H_d_t", q_hs_C_d_t)
-            _logger.NDdebug("E_E_fan_H_d_t", E_E_fan_C_d_t)
 
         _logger.NDdebug("E_E_CRAC_C_d_t", E_E_CRAC_C_d_t)
         _logger.NDdebug("E_E_fan_C_d_t", E_E_fan_C_d_t)

--- a/jjjexperiment/jjj_section4_2_a.py
+++ b/jjjexperiment/jjj_section4_2_a.py
@@ -1433,8 +1433,8 @@ def get_E_E_fan_H_d_t(type, P_fan_rtd_H, V_hs_vent_d_t, V_hs_supply_d_t, V_hs_ds
         type: 暖房設備の種類
         P_fan_rtd_H: 定格暖房能力運転時の送風機の消費電力（W）
         V_hs_vent_d_t: 日付dの時刻tにおける熱源機の風量のうちの全般換気分（m3/h）
-        V_hs_supply_d_t: param V_hs_dsgn_H:暖房時の設計風量（m3/h）
-        V_hs_dsgn_H:
+        V_hs_supply_d_t:
+        V_hs_dsgn_H: 暖房時の設計風量（m3/h）
         q_hs_H_d_t: 日付dの時刻tにおける1時間当たりの熱源機の平均暖房能力（W）
         f_SFP: ファンの比消費電力 (W/(m3・h))
 
@@ -1503,7 +1503,8 @@ def get_E_E_fan_C_d_t(type, P_fan_rtd_C, V_hs_vent_d_t, V_hs_supply_d_t, V_hs_ds
         type: 冷房設備の種類
         P_fan_rtd_C: 定格冷房能力運転時の送風機の消費電力（W）
         V_hs_vent_d_t: 日付dの時刻tにおける熱源機の風量のうちの全般換気分（m3/h）
-        V_hs_supply_d_t: param V_hs_dsgn_C:冷房時の設計風量（m3/h）
+        V_hs_supply_d_t:
+        V_hs_dsgn_C: 冷房時の設計風量（m3/h）
         V_hs_dsgn_C:
         q_hs_C_d_t: 日付dの時刻tにおける1時間当たりの熱源機の平均冷房能力（W）
         f_SFP: ファンの比消費電力 (W/(m3・h))


### PR DESCRIPTION
エアコンのファンの電力を間違って入れていました。
ダクトセントラル・ルームエアコン活用型と同様の数式に変更しました。

Before -> After

> type1: ダクトセントラル
> E_E_fan_C_d_t[MAX]  : 0.2172860187872
> E_E_fan_C_d_t[ZEROS]: 6777
> E_E_fan_C_d_t[AVG.] : 0.21728601878719994
> 
> type2: ルームエアコン活用型
> E_E_fan_C_d_t[MAX]  : 0.14052867840000002
> E_E_fan_C_d_t[ZEROS]: 6777
> E_E_fan_C_d_t[AVG.] : 0.14052867840000002
> 
> type3: 潜熱評価方式
> E_E_fan_C_d_t[MAX]  : 1.0393421447287183
> E_E_fan_C_d_t[ZEROS]: 6778
> E_E_fan_C_d_t[AVG.] : 0.18279820426577606
> 
> type4: 電中研方式
> E_E_fan_C_d_t[MAX]  : 0.03574185003048647 -> 0.21728601878720005
> E_E_fan_C_d_t[ZEROS]: 6778
> E_E_fan_C_d_t[AVG.] : 0.035741850030486466 -> 0.21728601878720005

他方式に近い値となりました。（ダクトセントラルと一致）

方式1,2,4 は同じ数式を使用して計算しています。

```
  if type == PROCESS_TYPE_1 or type == PROCESS_TYPE_2 or type == PROCESS_TYPE_4:

      fx = (P_fan_rtd_C - f_SFP * V_hs_vent_d_t) \
          * ((V_hs_supply_d_t - V_hs_vent_d_t) / (V_hs_dsgn_C - V_hs_vent_d_t)) * 10 ** (-3)

      E_E_fan_C_d_t = np.zeros(24 * 365)
      E_E_fan_C_d_t[q_hs_C_d_t > 0] = np.clip(fx[q_hs_C_d_t > 0], 0, None)

  elif type == PROCESS_TYPE_3:
      x = q_hs_C_d_t / 1000  # WARNING: 例外的に四次式では kW 単位で計算しています
      P_fan_C_d_t = constants.P_fan_C_d_t_a4 * x**4  \
                  + constants.P_fan_C_d_t_a3 * x**3  \
                  + constants.P_fan_C_d_t_a2 * x**2  \
                  + constants.P_fan_C_d_t_a1 * x  \
                  + constants.P_fan_C_d_t_a0

      fx = (P_fan_C_d_t - f_SFP * V_hs_vent_d_t) * 10 ** (-3)

      E_E_fan_C_d_t = np.zeros(24 * 365)
      E_E_fan_C_d_t[q_hs_C_d_t > 0] = np.clip(fx[q_hs_C_d_t > 0], 0, None)
```
