### PR TITLE
debug: 電中研モデルの冷房が暖房設定に誤って依存箇所

### DIFF
--- a/jjjexperiment/calc.py
+++ b/jjjexperiment/calc.py
@@ -29,7 +29,7 @@ def version_info() -> str:
     """
     # NOTE: subprocessモジュールによるコミット履歴からの生成は \
     # ipynb 環境では正常に動作しませんでした(returned no-zero exit status 128.)
-    return '_20231025'
+    return '_20231107'
 
 def calc_Q_UT_A(case_name, A_A, A_MR, A_OR, A_env, mu_H, mu_C, q_hs_rtd_H, q_hs_rtd_C, q_rtd_H, q_rtd_C, q_max_H, q_max_C, V_hs_dsgn_H, V_hs_dsgn_C, Q,
             VAV, general_ventilation, hs_CAV, duct_insulation, region, L_H_d_t_i, L_CS_d_t_i, L_CL_d_t_i,

--- a/jjjexperiment/main.py
+++ b/jjjexperiment/main.py
@@ -305,8 +305,8 @@ def calc(input_data : dict, test_mode=False):
         outdoorFile = outdoorFile,
         simu_R_C= simu_R_C if C_A['type']==PROCESS_TYPE_4 else None,
         spec= spec         if C_A['type']==PROCESS_TYPE_4 else None,
-        Theta_real_inner=  T_real if H_A['type']==PROCESS_TYPE_4 else None,
-        RH_real_inner=    RH_real if H_A['type']==PROCESS_TYPE_4 else None)
+        Theta_real_inner=  T_real if C_A['type']==PROCESS_TYPE_4 else None,
+        RH_real_inner=    RH_real if C_A['type']==PROCESS_TYPE_4 else None)
 
     # CHECK: Q_UT_C の間違いではないのか
     df_output2['Q_UT_H_d_t_i [MJ/h']        = E_C_UT_d_t


### PR DESCRIPTION
冷房だけが「電中研モデル」の時にエラーとなっていました。
逆に、暖房だけ「電中研モデル」でもエラーにはならない。

![スクリーンショット 2023-11-07 175237](https://github.com/iguchi-lab/jjj_experiment/assets/129730757/08bde5e8-9d04-4b1d-a0ce-ac74dc477038)

修正しました。